### PR TITLE
Add id_str as generic unique id field option

### DIFF
--- a/app/services/import/reduction.rb
+++ b/app/services/import/reduction.rb
@@ -77,6 +77,10 @@ module Import
       unique_id = subject_metadata['#name']
       return unique_id if unique_id
 
+      # generic metadata
+      unique_id = subject_metadata['id_str'] || subject_metadata['!id_str'] || subject_metadata['#id_str']
+      return unique_id if unique_id
+
       # staging has older data with different subject metadata - fallback to handling this special env case
       subject_metadata['!SDSS_ID'] if Rails.env.staging? || Rails.env.test?
     end


### PR DESCRIPTION
KADE requires a unique science id for each subject (for example, an identifier for a galaxy in the sky). 

It searches id, !id, #id, and #name. But Galaxy Zoo typically uses id_str in more recent projects (partly as id is a reserved keyword in Python). This PR adds id_str as a possible metadata option.

This should fix the KADE/Bajor Galaxy Zoo errors where unique id is not found.

In general it would be best to pick one metadata field and only ever use that field, but in practice it's easy to mess up when e.g. a large team shares uploading responsibilities. Oops on our end.

Mike