### PR TITLE
remove --schema flag from predictions

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -6,7 +6,8 @@ on:
     types:
       - completed
     branches:
-      - main
+      # - main
+      - jwst-test-deploy-branch
   workflow_dispatch:
 
 jobs:

--- a/lib/bajor/client.rb
+++ b/lib/bajor/client.rb
@@ -40,7 +40,7 @@ module Bajor
     def create_prediction_job(manifest_url, prediction_opts = {})
       bajor_response = self.class.post(
         '/prediction/jobs/',
-        body: { manifest_url: manifest_url, opts: build_opts(prediction_opts) }.to_json,
+        body: { manifest_url: manifest_url, opts: build_opts(prediction_opts, false) }.to_json,
         headers: JSON_HEADERS
       )
 
@@ -136,18 +136,20 @@ module Bajor
       "https://bajor#{service_host_suffix}.zooniverse.org"
     end
 
-    def build_opts(options)
+    def build_opts(options, include_schema=true)
       raw = options.with_indifferent_access
       overrides = raw.symbolize_keys.slice(:workflow_name, :fixed_crop)
 
       DEFAULT_OPTIONS
       .merge(overrides)
       .compact.tap do |o|
-        o[:run_opts] = "--schema #{o[:workflow_name].downcase}"
+        run_opts = []
+        run_opts << "--schema #{o[:workflow_name].downcase}" if include_schema
         if o[:fixed_crop].present?
-          o[:run_opts] += " --fixed_crop #{o[:fixed_crop].to_json}"
+          run_opts << "--fixed-crop #{o[:fixed_crop].to_json}"
           o.delete(:fixed_crop)
         end
+        o[:run_opts] = run_opts.join(' ') if run_opts.any?
       end
     end
   end


### PR DESCRIPTION
Fixes this error seen while testing
```

usage: predict_catalog_with_model.py [-h] --checkpoint-path CHECKPOINT_PATH
                                     --save-path SAVE_LOC --catalog-url
                                     CATALOG_URL [--num-samples NUM_SAMPLES]
                                     [--num-workers NUM_WORKERS]
                                     [--prefetch-factor PREFETCH_FACTOR]
                                     [--batch-size BATCH_SIZE]
                                     [--accelerator ACCELERATOR]
                                     [--devices DEVICES]
                                     [--erase-iterations ERASE_ITERATIONS]
                                     [--fixed-crop FIXED_CROP]
predict_catalog_with_model.py: error: unrecognized arguments: --schema euclid
```

`--schema` flag is not needed on predictions and was not included before this [pr](https://github.com/zooniverse/kade/pull/197)

Also rename `fixed_crop` to match `fixed-crop` on bajor [here](https://github.com/zooniverse/bajor/blob/c8431cfeebaba93cfb3502869bc4b72254f245ec/azure/batch/scripts/predict_catalog_with_model.py#L36)