### PR TITLE
add appropriate TASK_KEY_LABEL_PREFIXES and TASK_KEY_DATA_LABELS to jwst label extractor

### DIFF
--- a/app/modules/label_extractors/galaxy_zoo/jwst_cosmos.rb
+++ b/app/modules/label_extractors/galaxy_zoo/jwst_cosmos.rb
@@ -8,6 +8,7 @@ module LabelExtractors
       # https://github.com/mwalmsley/galaxy-datasets/blob/a1a653ec7ab228036129acecb6a26b9960dbb5ff/galaxy_datasets/shared/label_metadata.py#L568
       TASK_KEY_LABEL_PREFIXES = {
         'T0' => 'smooth-or-featured',
+        'T1' => 'how-rounded',
         'T2' => 'disk-edge-on',
         'T3' => 'edge-on-bulge',
         'T4' => 'bar',
@@ -23,7 +24,12 @@ module LabelExtractors
         'T0' => {
           '0' => 'smooth',
           '1' => 'featured-or-disk',
-          '2' => 'problem'
+          '2' => 'star-artifact-zoom'
+        },
+        'T1' => {
+          '0' => 'round',
+          '1' => 'in-between',
+          '2' => 'cigar-shaped'
         },
         'T2' => {
           '0' => 'yes',
@@ -76,7 +82,7 @@ module LabelExtractors
         'T19' => {
           '0' => 'star',
           '1' => 'artifact',
-          '2' => 'zoom'
+          '2' => 'bad-zoom'
         }
       }.freeze
 


### PR DESCRIPTION
Solves for the error below seen while testing

```
KeyError: Caught KeyError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop
    data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/data/_utils/fetch.py", line 52, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/usr/local/lib/python3.10/dist-packages/galaxy_datasets/pytorch/galaxy_dataset.py", line 88, in __getitem__
    label = get_galaxy_label(galaxy, self.label_cols)
  File "/usr/local/lib/python3.10/dist-packages/galaxy_datasets/pytorch/galaxy_dataset.py", line 187, in get_galaxy_label
    galaxy[label_cols].astype(np.float32).values.squeeze()
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/series.py", line 1153, in __getitem__
    return self._get_with(key)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/series.py", line 1194, in _get_with
    return self.loc[key]
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexing.py", line 1191, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexing.py", line 1420, in _getitem_axis
    return self._getitem_iterable(key, axis=axis)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexing.py", line 1360, in _getitem_iterable
    keyarr, indexer = self._get_listlike_indexer(key, axis)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexing.py", line 1558, in _get_listlike_indexer
    keyarr, indexer = ax._get_indexer_strict(key, axis_name)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexes/base.py", line 6200, in _get_indexer_strict
    self._raise_if_missing(keyarr, indexer, axis_name)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/indexes/base.py", line 6252, in _raise_if_missing
    raise KeyError(f"{not_found} not in index")
KeyError: "['smooth-or-featured-jwst_star-artifact-zoom', 'how-rounded-jwst_round', 'how-rounded-jwst_in-between', 'how-rounded-jwst_cigar-shaped', 'problem-jwst_bad-zoom'] not in index"


```