### PR TITLE
add quotes to fixed-crop value so can be parsed properly on azure batch

### DIFF
--- a/lib/bajor/client.rb
+++ b/lib/bajor/client.rb
@@ -146,7 +146,7 @@ module Bajor
         run_opts = []
         run_opts << "--schema #{o[:workflow_name].downcase}" if include_schema
         if o[:fixed_crop].present?
-          run_opts << "--fixed-crop #{o[:fixed_crop].to_json}"
+          run_opts << "--fixed-crop '#{o[:fixed_crop].to_json}'"
           o.delete(:fixed_crop)
         end
         o[:run_opts] = run_opts.join(' ') if run_opts.any?

--- a/spec/lib/bajor/client_spec.rb
+++ b/spec/lib/bajor/client_spec.rb
@@ -10,7 +10,7 @@ def build_expected_body(manifest_url: nil, manifest_path: nil, workflow_name:, f
 
   run_opts = []
   run_opts << "--schema #{workflow_name}" if manifest_path
-  run_opts << "--fixed-crop #{fixed_crop.to_json}" if fixed_crop
+  run_opts << "--fixed-crop '#{fixed_crop.to_json}'" if fixed_crop
   opts[:run_opts] = run_opts.join(' ') unless run_opts.empty?
 
   if manifest_url


### PR DESCRIPTION
Solves for this error while testing


```
 PYTORCH_KERNEL_CACHE_PATH=/mnt/batch/tasks/shared/.cache/torch/kernels
+ HF_HOME=/mnt/batch/tasks/shared/.cache/huggingface
+ python /mnt/batch/tasks/shared/train_model_finetune_on_catalog.py --schema jwst_cosmos --fixed-crop lower_left_x:30 lower_left_y:30 upper_right_x:750 upper_right_y:750 --debug --wandb --checkpoint /mnt/batch/tasks/fsmounts/models/zoobot_pretrained_model_staging.ckpt --catalog /mnt/batch/tasks/fsmounts/training/catalogues/staging/workflow-3852-2025-05-02T02:43:02+00:00.csv --save-dir /mnt/batch/tasks/fsmounts/training/jobs/2025-05-02T11:00_81920ebd-d0d0-4f01-b796-4a0016be3d13/results/
/usr/local/lib/python3.10/dist-packages/albumentations/__init__.py:24: UserWarning: A new version of Albumentations is available: 2.0.6 (you have 1.4.24). Upgrade using: pip install -U albumentations. To disable automatic update checks, set the environment variable NO_ALBUMENTATIONS_UPDATE to 1.
  check_for_updates()
2025-05-02 11:17:20,482 INFO: Begin training on catalog
usage: train_model_finetune_on_catalog.py [-h] --save-dir SAVE_DIR --catalog
                                          CATALOG_LOC --checkpoint CHECKPOINT
                                          [--schema SCHEMA]
                                          [--num-workers NUM_WORKERS]
                                          [--prefetch-factor PREFETCH_FACTOR]
                                          [--batch-size BATCH_SIZE]
                                          [--accelerator ACCELERATOR]
                                          [--devices DEVICES] [--progress-bar]
                                          [--encoder-dim ENCODER_DIM]
                                          [--n-layers N_LAYERS]
                                          [--num-epochs NUM_EPOCHS]
                                          [--save-top-k SAVE_TOP_K]
                                          [--patience PATIENCE] [--wandb]
                                          [--debug]
                                          [--erase-iterations ERASE_ITERATIONS]
                                          [--fixed-crop FIXED_CROP]
train_model_finetune_on_catalog.py: error: unrecognized arguments: lower_left_y:30 upper_right_x:750 upper_right_y:750

```

Adding quotes to the string so they can be used to run the script correctly