### PR TITLE
Notify on subject retirement

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,4 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: "no-reply@zooniverse.org"
+  layout 'mailer'
+end

--- a/app/mailers/project_notification_mailer.rb
+++ b/app/mailers/project_notification_mailer.rb
@@ -1,0 +1,11 @@
+class ProjectNotificationMailer < ApplicationMailer
+    layout false
+
+    def notify_subject_completion(user, context, completion_percentage)
+      @completion_percentage = completion_percentage
+      @project_name = context.module_name
+      @workflow_name = context.extractor_name
+      @email_to = user['email']
+      mail(to: @email_to, subject: "Your subjects are almost retired ")
+    end
+  end

--- a/app/mailers/project_notification_mailer.rb
+++ b/app/mailers/project_notification_mailer.rb
@@ -6,6 +6,6 @@ class ProjectNotificationMailer < ApplicationMailer
       @project_name = context.module_name
       @workflow_name = context.extractor_name
       @email_to = user['email']
-      mail(to: @email_to, subject: "Your subjects are almost retired ")
+      mail(to: @email_to, subject: "Your subjects are almost retired")
     end
   end

--- a/app/services/prediction_results/process.rb
+++ b/app/services/prediction_results/process.rb
@@ -5,6 +5,7 @@ require 'remote_file/reader'
 module PredictionResults
   class Process
     SUBJECT_ACTION_API_BATCH_SIZE = ENV.fetch('SUBJECT_ACTION_API_BATCH_SIZE', '10').to_i
+    COMPLETION_NOTIFICATION_THRESHOLD = ENV.fetch('COMPLETION_NOTIFICATION_THRESHOLD', '0.95').to_f
 
     attr_accessor :results_url, :subject_set_id, :probability_threshold,
                   :over_threshold_subject_ids, :under_threshold_subject_ids,
@@ -19,6 +20,7 @@ module PredictionResults
       @under_threshold_subject_ids = []
       @random_spice_subject_ids = []
       @prediction_data = nil
+      @total_subjects = 0
     end
 
     def run
@@ -50,6 +52,8 @@ module PredictionResults
         @over_threshold_subject_ids << subject_id if probability >= probability_threshold
         @under_threshold_subject_ids << subject_id if probability < probability_threshold
       end
+      @total_subjects = @over_threshold_subject_ids.count + @under_threshold_subject_ids.count
+      check_completion_and_notify
       # now add some 'spice' to the results by adding some random under threshold subject ids
       # but don't skew the prediction results by adding too many under threshold images
       # ensure we only use apply the randomisation factor to the count of over threshold subject ids
@@ -83,6 +87,15 @@ module PredictionResults
       subject_ids
         .each_slice(SUBJECT_ACTION_API_BATCH_SIZE)
         .map { |batch_subject_ids| [batch_subject_ids, subject_set_id] }
+    end
+
+    private
+    def check_completion_and_notify
+      total_under_threshold_subjects = @under_threshold_subject_ids.count
+      completion_rate = (total_under_threshold_subjects.to_f / @total_subjects.to_f)
+      if completion_rate >= COMPLETION_NOTIFICATION_THRESHOLD
+        NotifyProjectOwnerJob.perform_async(subject_set_id, completion_rate)
+      end
     end
   end
 end

--- a/app/services/prediction_results/process.rb
+++ b/app/services/prediction_results/process.rb
@@ -41,6 +41,7 @@ module PredictionResults
     end
 
     def partition_results
+      @total_subjects = prediction_data.count
       prediction_data.each do |subject_id, prediction_samples|
         # data schema format is published in the file
         # and https://github.com/zooniverse/bajor/blob/main/azure/batch/scripts/predict_on_catalog.py
@@ -52,7 +53,6 @@ module PredictionResults
         @over_threshold_subject_ids << subject_id if probability >= probability_threshold
         @under_threshold_subject_ids << subject_id if probability < probability_threshold
       end
-      @total_subjects = @over_threshold_subject_ids.count + @under_threshold_subject_ids.count
       check_completion_and_notify
       # now add some 'spice' to the results by adding some random under threshold subject ids
       # but don't skew the prediction results by adding too many under threshold images

--- a/app/sidekiq/notify_project_owner_job.rb
+++ b/app/sidekiq/notify_project_owner_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'panoptes/api'
+
+class NotifyProjectOwnerJob
+  include Sidekiq::Job
+  sidekiq_options retry: 5
+
+  def perform(subject_set_id, completion_rate)
+    @context = Context.find_by!(active_subject_set_id: subject_set_id)
+
+    owner_link = fetch_project_owner
+    owner_user = fetch_owner_user(owner_link['id'])
+
+    ProjectNotificationMailer
+      .notify_subject_completion(owner_user, @context, (completion_rate * 100))
+      .deliver_now
+  end
+
+  private
+  def fetch_project_owner(max_retries = 3)
+    with_api_retry(max_retries) do
+      resp = Panoptes::Api.client.project(@context.project_id)
+      resp['links']['owner']
+    end
+  end
+
+  def fetch_owner_user(owner_id, max_retries = 3)
+    with_api_retry(max_retries) do
+      Panoptes::Api.client.user(owner_id)
+    end
+  end
+
+
+  def with_api_retry(max_retries)
+    attempts = 0
+
+    begin
+      yield
+    rescue Panoptes::Client::ServerError => e
+      attempts += 1
+      raise if attempts > max_retries
+
+      sleep(rand(max_retries))
+      retry
+    ensure
+      Faraday.default_connection.close
+    end
+  end
+end

--- a/app/views/project_notification_mailer/notify_subject_completion.html.erb
+++ b/app/views/project_notification_mailer/notify_subject_completion.html.erb
@@ -1,0 +1,6 @@
+<!-- app/views/project_notification_mailer/notify_subject_completion.html.erb -->
+<p>Subjects belonging to <%= @workflow_name %> workflow of project: <%= @project_name %> have hit <%= @completion_percentage %>% completion</p>
+
+<p>Thanks,</p>
+
+<p>The Zooniverse Team</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'active_model/railtie'
 require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'active_storage/engine'
+require "action_mailer/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/mailers/project_notification_mailer_spec.rb
+++ b/spec/mailers/project_notification_mailer_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe ProjectNotificationMailer, :type => :mailer do
+  let(:user) { { 'email' => 'test@project@owner.com' } }
+  let(:context) { Context.first }
+  let(:completion_percentage) { 96 }
+  let(:mail) { ProjectNotificationMailer.notify_subject_completion(user, context, completion_percentage)}
+
+  describe "#notify_subject_completion" do
+
+    it "mails the correct user" do
+      expect(mail.to).to include(user['email'])
+    end
+
+    it 'comes from no-reply@zooniverse.org' do
+      expect(mail.from).to include('no-reply@zooniverse.org')
+    end
+
+    it 'has the correct subject' do
+      expect(mail.subject).to eq("Your subjects are almost retired")
+    end
+
+    it 'has the project name in the body' do
+      expect(mail.body.encoded).to match("#{context.module_name}")
+    end
+
+    it 'has the workflow name in the body' do
+      expect(mail.body.encoded).to match("#{context.extractor_name}")
+    end
+
+    it 'has the completion percentage in the body' do
+      expect(mail.body.encoded).to match("#{completion_percentage}%")
+    end
+  end
+end

--- a/spec/services/prediction_results/process_spec.rb
+++ b/spec/services/prediction_results/process_spec.rb
@@ -93,6 +93,18 @@ RSpec.describe PredictionResults::Process do
       expect(process_results_service.under_threshold_subject_ids).to be_empty
       expect(process_results_service.random_spice_subject_ids).to match_array([under_threshold_subject_id])
     end
+
+    context 'when completion hits the notification threshold' do
+      before do
+        stub_const("PredictionResults::Process::COMPLETION_NOTIFICATION_THRESHOLD", 0.5)
+        allow(NotifyProjectOwnerJob).to receive(:perform_async)
+      end
+
+      it 'calls NotifyProjectOwnerJob for almost retired subjects' do
+        process_results_service.partition_results
+        expect(NotifyProjectOwnerJob).to have_received(:perform_async).with(active_subject_set_id, 0.5)
+      end
+    end
   end
 
   describe '#move_over_threshold_subjects_to_active_set' do

--- a/spec/sidekiq/notify_project_owner_job_spec.rb
+++ b/spec/sidekiq/notify_project_owner_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NotifyProjectOwnerJob, type: :job do
+  describe 'perform' do
+    let(:context) { Context.first }
+    let(:job) { described_class.new }
+    let(:panoptes_client_double) { instance_double(Panoptes::Client) }
+    let(:fake_owner_id)   { 1 }
+    let(:fake_user_hash)  { { "id" => fake_owner_id, "email" => "foo@example.com", "display_name" => "Foo Bar" } }
+    let(:fake_project_hash)  { { "links" => { "owner" => { "id" => fake_owner_id } } } }
+    let(:completion_rate) { 0.9 }
+
+    let(:mailer_double) { instance_double("ActionMailer::MessageDelivery", deliver_now: true) }
+    before do
+      allow(ENV).to receive(:fetch).with('PANOPTES_OAUTH_CLIENT_ID').and_return('fake-client-id')
+      allow(ENV).to receive(:fetch).with('PANOPTES_OAUTH_CLIENT_SECRET').and_return('fake-client-sekreto')
+      allow(panoptes_client_double).to receive(:project).and_return(fake_project_hash)
+      allow(panoptes_client_double).to receive(:user).and_return(fake_user_hash)
+      allow(Panoptes::Client).to receive(:new).and_return(panoptes_client_double)
+      allow(ProjectNotificationMailer)
+      .to receive(:notify_subject_completion)
+      .and_return(mailer_double)
+      job.perform(context.active_subject_set_id, completion_rate)
+    end
+
+    it 'calls the api client to fetch project details' do
+      expect(panoptes_client_double).to have_received(:project).with(context.project_id)
+    end
+
+    it 'calls the api client to fetch user details' do
+      expect(panoptes_client_double).to have_received(:user).with(fake_owner_id)
+    end
+
+    it 'calls ProjectNotificationMailer notify_subject_completion' do
+      allow(ProjectNotificationMailer).to receive(:notify_subject_completion)
+      expect(ProjectNotificationMailer).to have_received(:notify_subject_completion).with(fake_user_hash, context, (completion_rate * 100))
+    end
+
+    it 'attempts to deliver the mail' do
+      expect(mailer_double).to have_received(:deliver_now)
+    end
+  end
+end


### PR DESCRIPTION
add logic to notify project owner on subject retirement.

Solves for point 1 on this [issue](https://github.com/zooniverse/kade/issues/214)