### PR TITLE
wrap Prediction::ExportManifest class api calls with exception catch

### DIFF
--- a/app/services/batch/prediction/export_manifest.rb
+++ b/app/services/batch/prediction/export_manifest.rb
@@ -8,6 +8,8 @@ module Batch
     class ExportManifest
       MANIFEST_SUBJECT_SET_BATCH_SIZE = ENV.fetch('MANIFEST_SUBJECT_SET_BATCH_SIZE', '10').to_i
 
+      MAX_RETRIES = 3
+      BASE_BACKOFF_SECONDS = 0.5
       attr_accessor :subject_set_id, :panoptes_client_pool, :manifest_data, :subject_set, :project_id, :temp_file, :subject_set_subject_ids
       attr_reader :manifest_url
 
@@ -55,7 +57,10 @@ module Batch
         # filtering on the subject_set_id
         # note this approach is what the Python Client does but in serial and it's slow
         # https://github.com/zooniverse/panoptes-python-client/blob/4b49b3c789462637fa6cb4677cbe05147dbae9d5/panoptes_client/subject_set.py#L83-L84
-        first_page = panoptes_client.panoptes.get('/set_member_subjects', query)
+        first_page = with_api_retry do
+          panoptes_client.panoptes.get('/set_member_subjects', query)
+        end
+        return unless first_page
         first_page['set_member_subjects'].each do |set_member_subject|
           subject_set_subject_ids << set_member_subject['links']['subject']
         end
@@ -69,11 +74,15 @@ module Batch
             results = page_nums.map do |page_num|
               page_query = { subject_set_id: subject_set_id, page: page_num }
               Async do
-                panoptes_client.panoptes.get('/set_member_subjects', page_query)
+                resp = with_api_retry do
+                  panoptes_client.panoptes.get('/set_member_subjects', page_query)
+                end
+                next unless resp
+                resp
               end
             end.map(&:wait)
             # process the async results into the subject_set_subject_ids
-            results.each do |page|
+            results.compact.each do |page|
               page['set_member_subjects'].each do |set_member_subject|
                 subject_set_subject_ids << set_member_subject['links']['subject']
               end
@@ -90,10 +99,14 @@ module Batch
           Async do
             subject_responses = batch_of_subject_ids.map do |subject_id|
               Async do
-                panoptes_client.subject(subject_id)
+                resp = with_api_retry do
+                  panoptes_client.subject(subject_id)
+                end
+                next unless resp
+                resp
               end
             end.map(&:wait)
-            subject_responses.each do |subject|
+            subject_responses.compact.each do |subject|
               # Create a data row for the first frame in the Subject
               location = subject['locations'].first
               frame_id = 0
@@ -137,6 +150,34 @@ module Batch
           filename: storage_filename,
           service_name: service_name
         )
+      end
+
+
+      private
+      def with_api_retry(max_retries = MAX_RETRIES)
+        attempts = 0
+
+        begin
+          yield
+        rescue StandardError => e
+          attempts += 1
+          if attempts < max_retries
+            backoff = BASE_BACKOFF_SECONDS * attempts
+            Rails.logger.warn(
+              "[ExportManifest] Attempt #{attempts}/#{max_retries} raised #{e.class.name}: #{e.message}. " \
+              "Retrying in #{backoff}s..."
+            )
+            sleep(backoff)
+            retry
+          else
+            Rails.logger.warn(
+              "[ExportManifest] All #{max_retries} attempts failed: #{e.class.name} – #{e.message}. Skipping."
+            )
+            return nil
+          end
+        ensure
+          Faraday.default_connection.close
+        end
       end
     end
   end

--- a/spec/services/batch/prediction/export_manifest_spec.rb
+++ b/spec/services/batch/prediction/export_manifest_spec.rb
@@ -48,4 +48,39 @@ RSpec.describe Batch::Prediction::ExportManifest do
       expect(service.manifest_url).to eq("#{Bajor::Client::BLOB_STORE_HOST_CONTAINER_URL}/predictions#{blob_double.key}")
     end
   end
+
+  describe '#with_api_retry' do
+    let(:subject_set_id) { 1 }
+    let(:pool) { ConnectionPool.new(size: 1, timeout: 1) { Panoptes::Api.client } }
+    let(:service) { described_class.new(subject_set_id, pool) }
+
+    before do
+      allow(described_class).to receive(:sleep)
+    end
+
+    it 'retries a failing block up to max_retries then returns nil' do
+      call_count = 0
+
+      result = service.send(:with_api_retry, 2) do
+        call_count += 1
+        raise StandardError
+      end
+
+      expect(call_count).to eq(2)
+      expect(result).to be_nil
+    end
+
+    it 'succeeds on the second attempt if first raises an exception' do
+      call_count = 0
+
+      result = service.send(:with_api_retry, 3) do
+        call_count += 1
+        raise StandardError, 'failed call' if call_count == 1
+        call_count
+      end
+
+      expect(call_count).to eq(2)
+      expect(result).to eq(call_count)
+    end
+  end
 end


### PR DESCRIPTION
wrap Prediction::ExportManifest class api calls with exception catch and retries.
Investigating why prediction jobs don't run after training, noticed this error in the logs:

`
{"time":"2025-06-06T11:24:54+00:00","severity":"warn","class":"Async::Task","oid":11909160,"pid":1,"subject":"#<Async::Task:0x0000000000b5b828 /usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:68:in `backtrace' (failed)>","message":["Task may have ended with unhandled exception.","859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'"],"error":{"kind":"Faraday::ParsingError","message":"859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'","stack":"/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n\nCaused by: Faraday::ParsingError 859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n\nCaused by: JSON::ParserError 859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n"}}
{"time":"2025-06-06T11:24:55+00:00","severity":"warn","class":"Async::Task","oid":11909180,"pid":1,"subject":"#<Async::Task:0x0000000000b5b83c /usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:68:in `backtrace' (failed)>","message":["Task may have ended with unhandled exception.","859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'"],"error":{"kind":"Faraday::ParsingError","message":"859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'","stack":"/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n\nCaused by: Faraday::ParsingError 859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n\nCaused by: JSON::ParserError 859: unexpected token at '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/lib/ruby/3.1.0/json/common.rb:216:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/parse_json.rb:13:in `block in <class:ParseJson>'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:54:in `parse'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:43:in `process_response'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:37:in `block in call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'\n/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/request/encode_json.rb:26:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/api_v1.rb:11:in `call'\n/usr/local/bundle/gems/faraday-panoptes-0.4.0/lib/faraday/panoptes/client_credentials_authentication.rb:25:in `call'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'\n/usr/local/bundle/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:67:in `request'\n/usr/local/bundle/gems/panoptes-client-1.2.0/lib/panoptes/endpoints/base_endpoint.rb:37:in `get'\n/rails_app/app/services/batch/prediction/export_manifest.rb:72:in `block (4 levels) in fetch_subject_set_subject_ids'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:107:in `block in run'\n/usr/local/bundle/gems/async-2.3.1/lib/async/task.rb:248:in `block in schedule'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:434:in `block (2 levels) in thread_block_with_current_transaction'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'\n/usr/local/bundle/gems/newrelic_rpm-9.7.0/lib/new_relic/agent/tracer.rb:433:in `block in thread_block_with_current_transaction'\n"}}
`.

My fix attempts to skip subject calls that fail after 3 retries