### PR TITLE
Add context runtime-config updates and decouple label extractor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
-  rescue_from LabelExtractors::GalaxyZoo::UnknownTaskKey, LabelExtractors::Finder::UnknownExtractor do |e|
+  rescue_from LabelExtractors::ConfigurationError,
+              LabelExtractors::UnknownTaskKey,
+              LabelExtractors::UnknownLabelKey,
+              LabelExtractors::GalaxyZoo::UnknownTaskKey,
+              LabelExtractors::GalaxyZoo::UnknownLabelKey,
+              LabelExtractors::Finder::UnknownExtractor do |e|
     # keep notifying HB about these errors - longer term remove if noisy
     Honeybadger.notify(e)
     # and respond to the client with a useful error message so they can fix it

--- a/app/controllers/contexts_controller.rb
+++ b/app/controllers/contexts_controller.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 class ContextsController < ApplicationController
+  class ValidationError < StandardError; end
+
+  CONTEXT_ATTRIBUTE_KEYS = %w[
+    workflow_id
+    project_id
+    active_subject_set_id
+    pool_subject_set_id
+    module_name
+    extractor_name
+  ].freeze
+  INTEGER_ATTRIBUTE_KEYS = %w[
+    workflow_id
+    project_id
+    active_subject_set_id
+    pool_subject_set_id
+  ].freeze
+  wrap_parameters false
+
   # as we're running in API mode we need to include basic auth
   include ActionController::HttpAuthentication::Basic::ControllerMethods
 
@@ -8,6 +26,16 @@ class ContextsController < ApplicationController
     name: Rails.application.config.api_basic_auth_username,
     password: Rails.application.config.api_basic_auth_password
   )
+
+  rescue_from ValidationError do |e|
+    json_error_render(:unprocessable_entity, e)
+  end
+  rescue_from Batch::RuntimeConfig::ValidationError do |e|
+    json_error_render(:unprocessable_entity, e)
+  end
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    json_error_render(:unprocessable_entity, e)
+  end
 
   def index
     contexts_scope = Context.order(id: :desc).limit(params_page_size)
@@ -23,5 +51,80 @@ class ContextsController < ApplicationController
       status: :ok,
       json: context.as_json
     )
+  end
+
+  def update
+    validate_context_params!
+
+    context = Context.find(params[:id])
+    attributes = context_params.slice(*CONTEXT_ATTRIBUTE_KEYS)
+
+    if context_params.key?('metadata')
+      metadata = context_metadata(context).deep_merge(context_params.fetch('metadata').to_h)
+      validate_batch_metadata!(metadata['batch']) if context_params.fetch('metadata').to_h.key?('batch')
+      attributes[:metadata] = metadata
+    end
+
+    context.update!(attributes)
+
+    render(
+      status: :ok,
+      json: context.as_json
+    )
+  end
+
+  private
+
+  def context_params
+    @context_params ||= params.permit(
+      *CONTEXT_ATTRIBUTE_KEYS,
+      :metadata,
+      metadata: {}
+    )
+  end
+
+  def validate_context_params!
+    raise ValidationError, 'at least one supported context field is required' if context_params.empty?
+
+    if context_params.key?('metadata') && !context_params['metadata'].respond_to?(:to_h)
+      raise ValidationError, 'metadata must be an object'
+    end
+
+    INTEGER_ATTRIBUTE_KEYS.each { |key| validate_integer_param!(key) if context_params.key?(key) }
+    validate_extractor_pair!
+  end
+
+  def context_metadata(context)
+    context.metadata.is_a?(Hash) ? context.metadata.deep_dup : {}
+  end
+
+  def validate_batch_metadata!(batch_config)
+    return if batch_config.nil?
+
+    unless batch_config.respond_to?(:to_h)
+      raise ValidationError, 'metadata.batch must be an object'
+    end
+
+    Batch::RuntimeConfig.validate!(batch_config)
+  end
+
+  def validate_extractor_pair!
+    return unless context_params.key?('module_name') || context_params.key?('extractor_name')
+
+    context = Context.find(params[:id])
+    module_name = context_params.key?('module_name') ? context_params['module_name'] : context.module_name
+    extractor_name = context_params.key?('extractor_name') ? context_params['extractor_name'] : context.extractor_name
+
+    return if LabelExtractors::Registry.extractor_registered?(module_name, extractor_name)
+
+    raise ValidationError, "unknown module/extractor pair: #{module_name}/#{extractor_name}"
+  end
+
+  def validate_integer_param!(key)
+    value = context_params[key]
+    return if value.is_a?(Integer)
+    return if value.is_a?(String) && value.match?(/\A\d+\z/)
+
+    raise ValidationError, "#{key} must be an integer"
   end
 end

--- a/app/models/label_extractor_definition.rb
+++ b/app/models/label_extractor_definition.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class LabelExtractorDefinition < ApplicationRecord
+  validates :module_name, :extractor_name, presence: true
+  validates :extractor_name, uniqueness: { scope: :module_name }
+  validates :config, presence: true
+  validate :config_shape
+
+  scope :enabled, -> { where(enabled: true) }
+
+  def self.find_enabled(module_name, extractor_name)
+    enabled.find_by(module_name: module_name, extractor_name: extractor_name)
+  end
+
+  private
+
+  def config_shape
+    LabelExtractors::ConfigurableExtractor.validate_config!(config)
+  rescue LabelExtractors::ConfigurationError => e
+    errors.add(:config, e.message)
+  end
+end

--- a/app/modules/label_extractors.rb
+++ b/app/modules/label_extractors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module LabelExtractors
+  class ConfigurationError < StandardError; end
+  class UnknownTaskKey < StandardError; end
+  class UnknownLabelKey < StandardError; end
+end

--- a/app/modules/label_extractors/configurable_extractor.rb
+++ b/app/modules/label_extractors/configurable_extractor.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module LabelExtractors
+  class ConfigurableExtractor
+    attr_reader :task_lookup_key
+
+    def initialize(task_lookup_key, config)
+      @task_lookup_key = task_lookup_key
+      @config = self.class.normalize_config(config)
+      self.class.validate_config!(@config)
+      validate_task_key!
+    end
+
+    def extract(data_hash)
+      data_hash.transform_keys do |key|
+        "#{task_prefix}-#{data_release_suffix}_#{data_payload_label(key)}"
+      end
+    end
+
+    def self.question_answers_schema(config)
+      normalized_config = normalize_config(config)
+      validate_config!(normalized_config)
+      task_key_label_prefixes = normalized_config.fetch('task_key_label_prefixes')
+      task_key_data_labels = normalized_config.fetch('task_key_data_labels')
+      data_release_suffix = normalized_config.fetch('data_release_suffix')
+
+      task_key_label_prefixes.flat_map do |task_key, question_prefix|
+        task_key_data_labels.fetch(task_key).values.map do |answer_suffix|
+          "#{question_prefix}-#{data_release_suffix}_#{answer_suffix}"
+        end
+      end
+    end
+
+    def self.normalize_config(config)
+      config.to_h.deep_stringify_keys
+    end
+
+    def self.validate_config!(config)
+      raise ConfigurationError, 'config must be an object' unless config.is_a?(Hash)
+
+      validate_string!(config, 'data_release_suffix')
+      validate_hash!(config, 'task_key_label_prefixes')
+      validate_hash!(config, 'task_key_data_labels')
+      validate_task_mappings!(config)
+    end
+
+    def self.validate_string!(config, key)
+      return if config[key].is_a?(String) && config[key].present?
+
+      raise ConfigurationError, "#{key} must be a non-empty string"
+    end
+
+    def self.validate_hash!(config, key)
+      return if config[key].is_a?(Hash) && config[key].present?
+
+      raise ConfigurationError, "#{key} must be a non-empty object"
+    end
+
+    def self.validate_task_mappings!(config)
+      prefixes = config.fetch('task_key_label_prefixes')
+      labels = config.fetch('task_key_data_labels')
+      raise ConfigurationError, 'task key mappings must match' unless prefixes.keys.sort == labels.keys.sort
+
+      prefixes.each do |task_key, prefix|
+        raise ConfigurationError, "task_key_label_prefixes.#{task_key} must be a non-empty string" unless prefix.is_a?(String) && prefix.present?
+
+        task_labels = labels.fetch(task_key)
+        raise ConfigurationError, "task_key_data_labels.#{task_key} must be a non-empty object" unless task_labels.is_a?(Hash) && task_labels.present?
+
+        task_labels.each do |answer_key, answer_label|
+          raise ConfigurationError, "task_key_data_labels.#{task_key}.#{answer_key} must be a non-empty string" unless answer_label.is_a?(String) && answer_label.present?
+        end
+      end
+    end
+
+    private
+
+    def validate_task_key!
+      return if task_key_label_prefixes.key?(task_lookup_key) && task_key_data_labels.key?(task_lookup_key)
+
+      raise UnknownTaskKey, "key not found: #{task_lookup_key}"
+    end
+
+    def task_prefix
+      task_key_label_prefixes.fetch(task_lookup_key)
+    end
+
+    def data_payload_label(key)
+      label = task_key_data_labels.dig(task_lookup_key, key)
+      raise UnknownLabelKey, "key not found: #{key}" unless label
+
+      label
+    end
+
+    def data_release_suffix
+      @config.fetch('data_release_suffix')
+    end
+
+    def task_key_label_prefixes
+      @config.fetch('task_key_label_prefixes')
+    end
+
+    def task_key_data_labels
+      @config.fetch('task_key_data_labels')
+    end
+  end
+end

--- a/app/modules/label_extractors/finder.rb
+++ b/app/modules/label_extractors/finder.rb
@@ -3,20 +3,9 @@
 module LabelExtractors
   class Finder
     class UnknownExtractor < StandardError; end
-    class UnknownTaskKey < StandardError; end
-
-    # hard code Galaxy Zoo for now as these will fail due to missing constant lookup
-    # long term we can add these back in and make the lookup dynamic
-    EXTRACTOR_SCHEMA_CLASS_REGEX = /\A(galaxy_zoo)_(decals|cosmic_dawn|euclid|jwst_cosmos)_(.+)\z/.freeze
 
     def self.extractor_instance(task_schema_lookup_key)
-      # simulate a regex lookup failure with the || [nil, task_schema_lookup_key] as it'll raise a NameError when trying to constantize
-      schema_name_and_task = EXTRACTOR_SCHEMA_CLASS_REGEX.match(task_schema_lookup_key) || [nil, task_schema_lookup_key]
-      schema_klass = "LabelExtractors::#{schema_name_and_task[1].camelize}::#{schema_name_and_task[2].camelize}".constantize
-      task_key = schema_name_and_task[3].upcase
-      schema_klass.new(task_key)
-    rescue NameError => _e
-      raise UnknownExtractor, "no extractor class found for '#{schema_name_and_task[1]}'"
+      Registry.extractor_instance_from_lookup_key(task_schema_lookup_key)
     end
   end
 end

--- a/app/modules/label_extractors/registry.rb
+++ b/app/modules/label_extractors/registry.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module LabelExtractors
+  class Registry
+    DEFAULT_CODE_EXTRACTORS = {
+      'galaxy_zoo.cosmic_dawn' => 'LabelExtractors::GalaxyZoo::CosmicDawn',
+      'galaxy_zoo.decals' => 'LabelExtractors::GalaxyZoo::Decals',
+      'galaxy_zoo.euclid' => 'LabelExtractors::GalaxyZoo::Euclid',
+      'galaxy_zoo.jwst_cosmos' => 'LabelExtractors::GalaxyZoo::JwstCosmos'
+    }.freeze
+
+    class << self
+      def register(module_name, extractor_name, extractor_class)
+        code_extractors[registry_key(module_name, extractor_name)] = extractor_class
+      end
+
+      def extractor_registered?(module_name, extractor_name)
+        extractor_class_for(module_name, extractor_name).present? ||
+          LabelExtractorDefinition.find_enabled(module_name, extractor_name).present?
+      end
+
+      def extractor_instance(module_name, extractor_name, task_key)
+        extractor_class = extractor_class_for(module_name, extractor_name)
+        return extractor_class.new(task_key) if extractor_class
+
+        definition = LabelExtractorDefinition.find_enabled(module_name, extractor_name)
+        return ConfigurableExtractor.new(task_key, definition.config) if definition
+
+        raise Finder::UnknownExtractor, "no extractor class found for '#{module_name}_#{extractor_name}'"
+      end
+
+      def extractor_instance_from_lookup_key(task_schema_lookup_key)
+        module_name, extractor_name, task_key = parse_lookup_key(task_schema_lookup_key)
+        extractor_instance(module_name, extractor_name, task_key)
+      end
+
+      def label_column_headers(module_name, extractor_name)
+        %w[id_str file_loc] | question_answers_schema(module_name, extractor_name)
+      end
+
+      def question_answers_schema(module_name, extractor_name)
+        extractor_class = extractor_class_for(module_name, extractor_name)
+        return extractor_class.question_answers_schema if extractor_class
+
+        definition = LabelExtractorDefinition.find_enabled(module_name, extractor_name)
+        return ConfigurableExtractor.question_answers_schema(definition.config) if definition
+
+        raise Finder::UnknownExtractor, "no extractor class found for '#{module_name}_#{extractor_name}'"
+      end
+
+      def code_extractors
+        @code_extractors ||= DEFAULT_CODE_EXTRACTORS.dup
+      end
+
+      private
+
+      def extractor_class_for(module_name, extractor_name)
+        extractor = code_extractors[registry_key(module_name, extractor_name)]
+        extractor.is_a?(String) ? extractor.constantize : extractor
+      end
+
+      def parse_lookup_key(task_schema_lookup_key)
+        registry_keys = (code_extractors.keys + db_registry_keys).uniq.sort_by { |key| -key.length }
+        matched_key = registry_keys.find do |key|
+          lookup_prefix = key.tr('.', '_')
+          task_schema_lookup_key.start_with?("#{lookup_prefix}_")
+        end
+
+        raise Finder::UnknownExtractor, "no extractor class found for '#{task_schema_lookup_key}'" unless matched_key
+
+        module_name, extractor_name = matched_key.split('.', 2)
+        task_key = task_schema_lookup_key.delete_prefix("#{matched_key.tr('.', '_')}_").upcase
+
+        [module_name, extractor_name, task_key]
+      end
+
+      def db_registry_keys
+        LabelExtractorDefinition.enabled.pluck(:module_name, :extractor_name).map do |module_name, extractor_name|
+          registry_key(module_name, extractor_name)
+        end
+      end
+
+      def registry_key(module_name, extractor_name)
+        "#{module_name}.#{extractor_name}"
+      end
+    end
+  end
+end

--- a/app/modules/zoobot.rb
+++ b/app/modules/zoobot.rb
@@ -2,9 +2,7 @@
 
 module Zoobot
   def self.label_column_headers(module_name='GalaxyZoo', extractor_name='CosmicDawn')
-    schema_klass = "LabelExtractors::#{module_name}::#{extractor_name}".constantize
-    # as data sets change, switch to different mission label extractors, e.g. Decals is older
-    %w[id_str file_loc] | schema_klass.question_answers_schema
+    LabelExtractors::Registry.label_column_headers(module_name.underscore, extractor_name.underscore)
   end
 
   module Storage

--- a/app/services/batch/runtime_config.rb
+++ b/app/services/batch/runtime_config.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module Batch
+  class RuntimeConfig
+    class ValidationError < StandardError; end
+
+    SCRIPT_PATH_KEYS = %w[
+      training_script_path
+      prediction_script_path
+      promote_script_path
+    ].freeze
+    ALLOWED_KEYS = (
+      SCRIPT_PATH_KEYS + %w[
+        container_image_name
+        fixed_crop
+        n_blocks
+        pretrained_checkpoint_url
+      ]
+    ).freeze
+    FIXED_CROP_KEYS = %w[
+      lower_left_x
+      lower_left_y
+      upper_right_x
+      upper_right_y
+    ].freeze
+
+    def self.validate!(config)
+      new(config).validate!
+    end
+
+    def initialize(config)
+      @config = config.to_h.transform_keys(&:to_s)
+    end
+
+    def validate!
+      validate_keys!
+      validate_container_image_name!(@config['container_image_name']) if @config.key?('container_image_name')
+      validate_script_paths!
+      validate_pretrained_checkpoint_url!(@config['pretrained_checkpoint_url']) if @config.key?('pretrained_checkpoint_url')
+      validate_n_blocks!(@config['n_blocks']) if @config.key?('n_blocks')
+      validate_fixed_crop!(@config['fixed_crop']) if @config.key?('fixed_crop')
+    end
+
+    private
+
+    def validate_keys!
+      unsupported_keys = @config.keys - ALLOWED_KEYS
+      return if unsupported_keys.empty?
+
+      raise ValidationError, "Unsupported batch runtime config keys: #{unsupported_keys.join(', ')}"
+    end
+
+    def validate_container_image_name!(value)
+      validate_non_blank_string!(value, 'container_image_name')
+      raise ValidationError, 'container_image_name must not contain whitespace' if value.match?(/\s/)
+    end
+
+    def validate_script_paths!
+      SCRIPT_PATH_KEYS.each do |key|
+        next unless @config.key?(key)
+
+        value = @config[key]
+        validate_relative_path!(value, key)
+        expected_extension = key == 'promote_script_path' ? '.sh' : '.py'
+        raise ValidationError, "#{key} must end with #{expected_extension}" unless value.end_with?(expected_extension)
+      end
+    end
+
+    def validate_pretrained_checkpoint_url!(value)
+      validate_non_blank_string!(value, 'pretrained_checkpoint_url')
+
+      if value.match?(%r{\Ahttps?://})
+        uri = URI.parse(value)
+        unless uri.is_a?(URI::HTTP) && uri.host.present? && uri.path.present? && uri.path != '/'
+          raise ValidationError, 'pretrained_checkpoint_url must be an HTTP(S) URL or relative checkpoint path'
+        end
+
+        validate_no_parent_path_segments!(uri.path.split('/'), 'pretrained_checkpoint_url')
+      elsif value.match?(%r{\A[A-Za-z][A-Za-z0-9+\-.]*://})
+        raise ValidationError, 'pretrained_checkpoint_url must be an HTTP(S) URL or relative checkpoint path'
+      else
+        validate_relative_path!(value, 'pretrained_checkpoint_url')
+      end
+    rescue URI::InvalidURIError
+      raise ValidationError, 'pretrained_checkpoint_url must be an HTTP(S) URL or relative checkpoint path'
+    end
+
+    def validate_n_blocks!(value)
+      return if value.is_a?(Integer) && value.positive?
+
+      raise ValidationError, 'n_blocks must be a positive integer'
+    end
+
+    def validate_fixed_crop!(value)
+      raise ValidationError, 'fixed_crop must be an object' unless value.respond_to?(:to_h)
+
+      fixed_crop = value.to_h.transform_keys(&:to_s)
+      missing_keys = FIXED_CROP_KEYS - fixed_crop.keys
+      unsupported_keys = fixed_crop.keys - FIXED_CROP_KEYS
+
+      raise ValidationError, "fixed_crop is missing required keys: #{missing_keys.join(', ')}" if missing_keys.any?
+      raise ValidationError, "fixed_crop has unsupported keys: #{unsupported_keys.join(', ')}" if unsupported_keys.any?
+
+      FIXED_CROP_KEYS.each do |key|
+        raise ValidationError, "fixed_crop.#{key} must be numeric" unless fixed_crop[key].is_a?(Numeric)
+      end
+    end
+
+    def validate_relative_path!(value, key)
+      validate_non_blank_string!(value, key)
+      raise ValidationError, "#{key} must be a relative path" if value.start_with?('/')
+      raise ValidationError, "#{key} must not contain whitespace" if value.match?(/\s/)
+      raise ValidationError, "#{key} must use forward slashes" if value.include?('\\')
+
+      validate_no_parent_path_segments!(value.split('/'), key)
+    end
+
+    def validate_no_parent_path_segments!(segments, key)
+      raise ValidationError, "#{key} must not include parent directory traversal" if segments.include?('..')
+    end
+
+    def validate_non_blank_string!(value, key)
+      raise ValidationError, "#{key} must be a string" unless value.is_a?(String)
+      raise ValidationError, "#{key} must not be blank" if value.blank?
+    end
+  end
+end

--- a/app/services/export/training_data.rb
+++ b/app/services/export/training_data.rb
@@ -10,12 +10,9 @@ module Export
 
     def run
       context = Context.find_by(workflow_id: training_data_export.workflow_id)
-      module_name = context.module_name.camelize
-      extractor_name = context.extractor_name.camelize
-      # create the formatted csv file export IO object
       csv_export_file = Format::TrainingDataCsv.new(
         training_data_export.workflow_id,
-        Zoobot.label_column_headers(module_name, extractor_name)
+        LabelExtractors::Registry.label_column_headers(context.module_name, context.extractor_name)
       ).run
 
       # upload the export file via active storage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
 
   resources :training_jobs, only: %i[index show]
 
-  resources :contexts, only: %i[index show]
+  resources :contexts, only: %i[index show update]
 
   # all other routes go here
 end

--- a/db/migrate/20260422000000_create_label_extractor_definitions.rb
+++ b/db/migrate/20260422000000_create_label_extractor_definitions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateLabelExtractorDefinitions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :label_extractor_definitions do |t|
+      t.string :module_name, null: false
+      t.string :extractor_name, null: false
+      t.boolean :enabled, null: false, default: true
+      t.jsonb :config, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index(
+      :label_extractor_definitions,
+      %i[module_name extractor_name],
+      unique: true,
+      name: 'index_label_extractor_definitions_on_module_and_extractor'
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_27_195821) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_22_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,16 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_27_195821) do
     t.string "extractor_name"
     t.jsonb "metadata"
     t.index ["workflow_id", "project_id"], name: "index_contexts_on_workflow_id_and_project_id", unique: true
+  end
+
+  create_table "label_extractor_definitions", force: :cascade do |t|
+    t.string "module_name", null: false
+    t.string "extractor_name", null: false
+    t.boolean "enabled", default: true, null: false
+    t.jsonb "config", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["module_name", "extractor_name"], name: "index_label_extractor_definitions_on_module_and_extractor", unique: true
   end
 
   create_table "prediction_jobs", force: :cascade do |t|

--- a/spec/modules/label_extractors/configurable_extractor_spec.rb
+++ b/spec/modules/label_extractors/configurable_extractor_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LabelExtractors::ConfigurableExtractor do
+  let(:config) do
+    {
+      'data_release_suffix' => 'np',
+      'task_key_label_prefixes' => {
+        'T0' => 'smooth-or-featured'
+      },
+      'task_key_data_labels' => {
+        'T0' => {
+          '0' => 'smooth',
+          '1' => 'featured',
+          '2' => 'artifact'
+        }
+      }
+    }
+  end
+
+  describe '#extract' do
+    it 'extracts labels using structured config' do
+      extractor = described_class.new('T0', config)
+
+      expect(extractor.extract('0' => 4, '1' => 2)).to eq(
+        'smooth-or-featured-np_smooth' => 4,
+        'smooth-or-featured-np_featured' => 2
+      )
+    end
+
+    it 'raises for unknown task keys' do
+      expect {
+        described_class.new('T99', config)
+      }.to raise_error(LabelExtractors::UnknownTaskKey, 'key not found: T99')
+    end
+
+    it 'raises for unknown answer keys' do
+      extractor = described_class.new('T0', config)
+
+      expect {
+        extractor.extract('99' => 1)
+      }.to raise_error(LabelExtractors::UnknownLabelKey, 'key not found: 99')
+    end
+
+    it 'raises a clear error for malformed config' do
+      malformed_config = config.except('task_key_data_labels')
+
+      expect {
+        described_class.new('T0', malformed_config)
+      }.to raise_error(LabelExtractors::ConfigurationError, 'task_key_data_labels must be a non-empty object')
+    end
+  end
+
+  describe '.question_answers_schema' do
+    it 'generates training data headers from config' do
+      expect(described_class.question_answers_schema(config)).to eq(
+        %w[
+          smooth-or-featured-np_smooth
+          smooth-or-featured-np_featured
+          smooth-or-featured-np_artifact
+        ]
+      )
+    end
+  end
+end

--- a/spec/modules/label_extractors/finder_spec.rb
+++ b/spec/modules/label_extractors/finder_spec.rb
@@ -32,5 +32,22 @@ RSpec.describe LabelExtractors::Finder do
       label_extractor = described_class.extractor_instance('galaxy_zoo_decals_t0')
       expect(label_extractor.task_lookup_key).to eq('T0')
     end
+
+    it 'finds DB-backed extractor definitions' do
+      LabelExtractorDefinition.create!(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: {
+          data_release_suffix: 'np',
+          task_key_label_prefixes: { T0: 'smooth-or-featured' },
+          task_key_data_labels: { T0: { '0': 'smooth' } }
+        }
+      )
+
+      label_extractor = described_class.extractor_instance('new_project_main_t0')
+
+      expect(label_extractor).to be_a(LabelExtractors::ConfigurableExtractor)
+      expect(label_extractor.task_lookup_key).to eq('T0')
+    end
   end
 end

--- a/spec/modules/label_extractors/registry_spec.rb
+++ b/spec/modules/label_extractors/registry_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LabelExtractors::Registry do
+  let(:config) do
+    {
+      'data_release_suffix' => 'np',
+      'task_key_label_prefixes' => {
+        'T0' => 'smooth-or-featured'
+      },
+      'task_key_data_labels' => {
+        'T0' => {
+          '0' => 'smooth'
+        }
+      }
+    }
+  end
+
+  describe '.extractor_instance' do
+    it 'resolves registered Galaxy Zoo code-backed extractors' do
+      extractor = described_class.extractor_instance('galaxy_zoo', 'cosmic_dawn', 'T0')
+
+      expect(extractor).to be_a(LabelExtractors::GalaxyZoo::CosmicDawn)
+    end
+
+    it 'falls back to enabled DB-backed extractor definitions' do
+      LabelExtractorDefinition.create!(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: config
+      )
+
+      extractor = described_class.extractor_instance('new_project', 'main', 'T0')
+
+      expect(extractor).to be_a(LabelExtractors::ConfigurableExtractor)
+    end
+
+    it 'prefers code-backed extractors over DB-backed definitions' do
+      LabelExtractorDefinition.create!(
+        module_name: 'galaxy_zoo',
+        extractor_name: 'cosmic_dawn',
+        config: config
+      )
+
+      extractor = described_class.extractor_instance('galaxy_zoo', 'cosmic_dawn', 'T0')
+
+      expect(extractor).to be_a(LabelExtractors::GalaxyZoo::CosmicDawn)
+    end
+
+    it 'raises a clear error when no extractor exists' do
+      expect {
+        described_class.extractor_instance('unknown_project', 'main', 'T0')
+      }.to raise_error(LabelExtractors::Finder::UnknownExtractor, "no extractor class found for 'unknown_project_main'")
+    end
+  end
+
+  describe '.extractor_instance_from_lookup_key' do
+    it 'resolves DB-backed extractors from lookup keys' do
+      LabelExtractorDefinition.create!(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: config
+      )
+
+      extractor = described_class.extractor_instance_from_lookup_key('new_project_main_t0')
+
+      expect(extractor.task_lookup_key).to eq('T0')
+    end
+  end
+
+  describe '.label_column_headers' do
+    it 'resolves DB-backed training CSV headers' do
+      LabelExtractorDefinition.create!(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: config
+      )
+
+      expect(described_class.label_column_headers('new_project', 'main')).to eq(
+        %w[id_str file_loc smooth-or-featured-np_smooth]
+      )
+    end
+  end
+
+  describe 'definition validation' do
+    it 'rejects malformed DB-backed extractor config' do
+      definition = LabelExtractorDefinition.new(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: config.except('task_key_label_prefixes')
+      )
+
+      expect(definition).not_to be_valid
+      expect(definition.errors[:config]).to include('task_key_label_prefixes must be a non-empty object')
+    end
+  end
+end

--- a/spec/requests/contexts_spec.rb
+++ b/spec/requests/contexts_spec.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Contexts', type: :request do
+  fixtures :contexts
+
+  let(:context) { contexts(:galaxy_zoo_cosmos_active_learning_project) }
+  let(:request_headers) do
+    json_headers_with_basic_auth(
+      Rails.application.config.api_basic_auth_username,
+      Rails.application.config.api_basic_auth_password
+    )
+  end
+
+  describe 'PATCH /contexts/:id' do
+    let(:path) { "/contexts/#{context.id}" }
+    let(:runtime_config) do
+      {
+        container_image_name: 'zoobot.azurecr.io/pytorch:custom-euclid',
+        training_script_path: 'euclid/train_model_finetune_on_catalog.py',
+        prediction_script_path: 'euclid/predict_catalog_with_model.py',
+        promote_script_path: 'euclid/promote_best_checkpoint_to_model.sh',
+        pretrained_checkpoint_url: 'https://kadeactivelearning.blob.core.windows.net/models/euclid/euclid-pretrained.ckpt',
+        n_blocks: 3,
+        fixed_crop: {
+          lower_left_x: 10,
+          lower_left_y: 20,
+          upper_right_x: 700,
+          upper_right_y: 710
+        }
+      }
+    end
+
+    it 'updates editable context attributes' do
+      patch(
+        path,
+        params: {
+          workflow_id: 234,
+          project_id: 45,
+          active_subject_set_id: 58,
+          pool_subject_set_id: 69,
+          module_name: 'galaxy_zoo',
+          extractor_name: 'euclid'
+        }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:ok)
+
+      context.reload
+      expect(context.workflow_id).to eq(234)
+      expect(context.project_id).to eq(45)
+      expect(context.active_subject_set_id).to eq(58)
+      expect(context.pool_subject_set_id).to eq(69)
+      expect(context.module_name).to eq('galaxy_zoo')
+      expect(context.extractor_name).to eq('euclid')
+    end
+
+    it 'accepts a DB-backed module and extractor pair' do
+      LabelExtractorDefinition.create!(
+        module_name: 'new_project',
+        extractor_name: 'main',
+        config: {
+          data_release_suffix: 'np',
+          task_key_label_prefixes: { T0: 'smooth-or-featured' },
+          task_key_data_labels: { T0: { '0': 'smooth' } }
+        }
+      )
+
+      patch(
+        path,
+        params: {
+          module_name: 'new_project',
+          extractor_name: 'main'
+        }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(context.reload.module_name).to eq('new_project')
+      expect(context.extractor_name).to eq('main')
+    end
+
+    it 'deep merges metadata without replacing existing metadata' do
+      patch(
+        path,
+        params: { metadata: { model_family: 'zoobot', labels: { source: 'api' } } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:ok)
+
+      context.reload
+      expect(context.metadata['fixed_crop']).to be_present
+      expect(context.metadata['batch']).to be_present
+      expect(context.metadata['model_family']).to eq('zoobot')
+      expect(context.metadata.dig('labels', 'source')).to eq('api')
+    end
+
+    it 'updates context attributes and batch runtime config in the same patch' do
+      patch(
+        path,
+        params: {
+          extractor_name: 'euclid',
+          metadata: { batch: runtime_config }
+        }.to_json,
+        headers: request_headers
+      )
+
+      expected_config = JSON.parse(runtime_config.to_json)
+
+      expect(response).to have_http_status(:ok)
+      expect(context.reload.extractor_name).to eq('euclid')
+      expect(context.metadata['batch']).to eq(expected_config)
+    end
+
+    it 'deep merges metadata.batch and preserves omitted existing batch keys' do
+      partial_runtime_config = {
+        pretrained_checkpoint_url: 'staging-euclid-zoobot.ckpt',
+        n_blocks: 3
+      }
+
+      patch(
+        path,
+        params: { metadata: { batch: partial_runtime_config } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(json_parsed_response_body.dig('metadata', 'batch', 'pretrained_checkpoint_url')).to eq('staging-euclid-zoobot.ckpt')
+      expect(json_parsed_response_body.dig('metadata', 'batch', 'n_blocks')).to eq(3)
+      expect(json_parsed_response_body.dig('metadata', 'batch', 'training_script_path')).to eq('jwst/train_model_finetune_on_catalog.py')
+      expect(context.reload.metadata.dig('batch', 'prediction_script_path')).to eq('jwst/predict_catalog_with_model.py')
+      expect(context.metadata['fixed_crop']).to be_present
+    end
+
+    it 'accepts a relative pretrained checkpoint path' do
+      runtime_config[:pretrained_checkpoint_url] = 'staging-euclid-zoobot.ckpt'
+
+      patch(
+        path,
+        params: { metadata: { batch: runtime_config } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(json_parsed_response_body.dig('metadata', 'batch', 'pretrained_checkpoint_url')).to eq('staging-euclid-zoobot.ckpt')
+    end
+
+    it 'rejects unsupported top-level patch keys' do
+      patch(
+        path,
+        params: { unsupported_key: 'bad' }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('at least one supported context field is required')
+    end
+
+    it 'rejects non-object JSON payloads' do
+      patch(
+        path,
+        params: ['invalid'].to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('at least one supported context field is required')
+    end
+
+    it 'rejects non-object metadata payloads' do
+      patch(
+        path,
+        params: { metadata: 'invalid' }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('metadata must be an object')
+    end
+
+    it 'rejects unknown module and extractor pairs' do
+      patch(
+        path,
+        params: {
+          module_name: 'new_project',
+          extractor_name: 'missing'
+        }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('unknown module/extractor pair: new_project/missing')
+    end
+
+    it 'rejects an extractor update that does not match the existing module' do
+      patch(
+        path,
+        params: {
+          extractor_name: 'missing'
+        }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('unknown module/extractor pair: galaxy_zoo/missing')
+    end
+
+    it 'rejects non-integer context IDs' do
+      patch(
+        path,
+        params: { workflow_id: 'not-an-integer' }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('workflow_id must be an integer')
+    end
+
+    it 'rejects unknown batch runtime config keys' do
+      patch(
+        path,
+        params: { metadata: { batch: runtime_config.merge(unknown_key: 'bad') } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('Unsupported batch runtime config keys')
+    end
+
+    it 'rejects unsafe script paths' do
+      runtime_config[:training_script_path] = '../train.py'
+
+      patch(
+        path,
+        params: { metadata: { batch: runtime_config } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('parent directory traversal')
+    end
+
+    it 'rejects unsupported checkpoint URL schemes' do
+      runtime_config[:pretrained_checkpoint_url] = 'ftp://example.com/models/euclid.ckpt'
+
+      patch(
+        path,
+        params: { metadata: { batch: runtime_config } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('HTTP(S) URL or relative checkpoint path')
+    end
+
+    it 'rejects non-object metadata batch payloads' do
+      patch(
+        path,
+        params: { metadata: { batch: 'invalid' } }.to_json,
+        headers: request_headers
+      )
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_parsed_response_body['errors'].first['detail']).to include('metadata.batch must be an object')
+    end
+
+    context 'with invalid authentication credentials' do
+      let(:request_headers) { json_headers_with_basic_auth('unknown', 'credentials') }
+
+      it 'returns unauthorized response' do
+        patch(
+          path,
+          params: { metadata: { batch: runtime_config } }.to_json,
+          headers: request_headers
+        )
+
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end

--- a/spec/requests/reductions_spec.rb
+++ b/spec/requests/reductions_spec.rb
@@ -160,6 +160,49 @@ RSpec.describe 'Reductions', type: :request do
       end
     end
 
+    context 'with a DB-backed label extractor definition' do
+      let(:context) do
+        Context.create!(
+          workflow_id: 555,
+          project_id: 42,
+          active_subject_set_id: 501,
+          pool_subject_set_id: 502,
+          module_name: 'new_project',
+          extractor_name: 'main'
+        )
+      end
+      let(:create_request) { post '/reductions/new_project_main_t0', params: reduction_json_payload, headers: create_request_headers }
+
+      before do
+        LabelExtractorDefinition.create!(
+          module_name: 'new_project',
+          extractor_name: 'main',
+          config: {
+            data_release_suffix: 'np',
+            task_key_label_prefixes: { T0: 'smooth-or-featured' },
+            task_key_data_labels: {
+              T0: {
+                '0': 'smooth',
+                '1': 'featured',
+                '2': 'artifact'
+              }
+            }
+          }
+        )
+      end
+
+      it 'creates a reduction using configurable labels' do
+        create_request
+
+        expect(response).to have_http_status(:created)
+        expect(json_parsed_response_body['labels']).to eq(
+          'smooth-or-featured-np_smooth' => 3,
+          'smooth-or-featured-np_featured' => 9,
+          'smooth-or-featured-np_artifact' => 0
+        )
+      end
+    end
+
     context 'with invalid authentication credentials' do
       let(:create_request_headers) do
         json_headers_with_basic_auth('unknown', 'credentials')

--- a/spec/services/export/training_data_spec.rb
+++ b/spec/services/export/training_data_spec.rb
@@ -59,5 +59,38 @@ RSpec.describe Export::TrainingData do
         expect(training_data_model.failed?).to be(true)
       end
     end
+
+    context 'with a DB-backed label extractor definition' do
+      let(:workflow_id) { 556 }
+
+      before do
+        Context.create!(
+          workflow_id: workflow_id,
+          project_id: 43,
+          active_subject_set_id: 601,
+          pool_subject_set_id: 602,
+          module_name: 'new_project',
+          extractor_name: 'main'
+        )
+        LabelExtractorDefinition.create!(
+          module_name: 'new_project',
+          extractor_name: 'main',
+          config: {
+            data_release_suffix: 'np',
+            task_key_label_prefixes: { T0: 'smooth-or-featured' },
+            task_key_data_labels: { T0: { '0': 'smooth' } }
+          }
+        )
+      end
+
+      it 'uses registry-backed label headers' do
+        export_service_instance.run
+
+        expect(Format::TrainingDataCsv).to have_received(:new).with(
+          workflow_id,
+          %w[id_str file_loc smooth-or-featured-np_smooth]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR does two related things:

1. adds a validated `PATCH /contexts/:id` update path for context fields and batch runtime metadata
2. decouples label extractor resolution from Galaxy Zoo by introducing a registry that supports both code and DB extractors

## What Changed

### Context update and batch runtime config
- adds `update` to `resources :contexts`
- adds request validation for editable context fields
- merges incoming `metadata`
- validates `metadata.batch` through `Batch::RuntimeConfig`
- rejects unresolved `module_name` / `extractor_name` pairs before persisting a context
- adds specs covering valid and invalid payloads

### Hybrid label extractor support
- adds `LabelExtractorDefinition` with JSONB-backed extractor config
- adds `LabelExtractors::Registry` for shared extractor resolution
- adds `LabelExtractors::ConfigurableExtractor` for DB-backed task/answer mappings
- updates `LabelExtractors::Finder` to resolve through the registry instead of the Galaxy Zoo-specific regex
- updates training export header resolution to use the registry
- preserves existing Galaxy Zoo extractor behavior as code-backed registrations

## Why

Previously:
- context updates for batch runtime config were not part of the standard `contexts` resource flow
- label extractor lookup was structurally tied to Galaxy Zoo naming and Ruby classes

This change makes:
- context runtime config editable through the API with validation
- simple new modules onboardable without adding a new Ruby extractor class
- reduction ingestion and training export use the same extractor resolution path