### PR TITLE
add fallback for unique_id on reductions

### DIFF
--- a/app/services/import/reduction.rb
+++ b/app/services/import/reduction.rb
@@ -89,8 +89,19 @@ module Import
       unique_id = subject_metadata['id_str'] || subject_metadata['!id_str'] || subject_metadata['#id_str'] || subject_metadata['#id_field']
       return unique_id if unique_id
 
+      # fallback if objectId
+      unique_id = subject_metadata['objectId'] || subject_metadata['!objectId'] || subject_metadata['#objectId']
+      return unique_id if unique_id
+
+      # fallback if fileId
+      unique_id = subject_metadata['fileId'] || subject_metadata['!fileId'] || subject_metadata['#fileId']
+      return unique_id if unique_id
+
       # staging has older data with different subject metadata - fallback to handling this special env case
-      subject_metadata['!SDSS_ID'] if Rails.env.staging? || Rails.env.test?
+      return subject_metadata['!SDSS_ID'] if Rails.env.staging? || Rails.env.test?
+
+      # fallback if to subject id
+      zooniverse_subject_id.to_s
     end
 
     # use a custom label extractor (injected at run time)

--- a/spec/services/import/reduction_spec.rb
+++ b/spec/services/import/reduction_spec.rb
@@ -107,6 +107,13 @@ RSpec.describe Import::Reduction do
         reduction_model_staging = described_class.new(staging_payload, label_extractor).run
         expect(reduction_model_staging.unique_id).to match('1237663785278570672')
       end
+
+      it 'falls back to the Zooniverse subject id when no metadata identifier exists' do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+        raw_payload[:subject]['metadata'].delete('id')
+        reduction_model_staging = described_class.new(raw_payload, label_extractor).run
+        expect(reduction_model_staging.unique_id).to match(zooniverse_subject_id.to_s)
+      end
     end
 
     context 'with a existing duplicate reduction' do


### PR DESCRIPTION
Resolves this [error](https://app.honeybadger.io/projects/99027/faults/92347322#notice-breadcrumbs).

Use zooniverse subject id as final fallback if no parameters found 